### PR TITLE
If the charset is not equal in the new thesaurus table created than m…

### DIFF
--- a/mod/admin/lib_mt_customization.inc
+++ b/mod/admin/lib_mt_customization.inc
@@ -231,7 +231,7 @@ function mt_customization_add_new_taxonomy() {
             ON DELETE CASCADE
             ON UPDATE CASCADE
 
-        ) ENGINE = InnoDB;";
+        ) ENGINE = InnoDB DEFAULT CHARSET=utf8;";
         
         $dbQuery->ExecuteNonQuery($table_sql);
 


### PR DESCRIPTION
…t_vocab the creation of the table fails, in this case we need both tables with default CHARSET=UTF8