### PR TITLE
Fix bug: showing mt codes instead of terms in analysis reports

### DIFF
--- a/mod/analysis/analysisModule.class.php
+++ b/mod/analysis/analysisModule.class.php
@@ -1279,7 +1279,7 @@ HAVING order_id = min( order_id ) ) as ori WHERE allowed = 0 )";
         }
         $number_of_fields = count($fields_array);
         $response->aaData = array();
-
+        
         foreach ($res as $key => $val) {
             //$response->aaData[$i]['id'] = $val[$fields_array[0]];
             $array_values = array();
@@ -1373,6 +1373,7 @@ HAVING order_id = min( order_id ) ) as ori WHERE allowed = 0 )";
     private function fix_selects($query)
     {
         $fields_array = array();
+        $entities = analysis_get_search_entities();
 
         if ($query->group_by != NULL) {
             //if the query is a count put group by field to the array


### PR DESCRIPTION
This pull request fixes the following issue

Task 839: data in reports and exported to excel have micro-thesauri codes instead of the corresponding terms

The fix was on line 1376 in `analysisModule.class.php`:

```
$entities = analysis_get_search_entities();
```

The issue only affected "virtual" entities like Victims and Perpetrators and not "true" entities like Persons. It occurred because MT fields were not detected as such in the `fix_selects` method when they were attached to "virtual" fields since the array that contained entities metadata (which is what was added on line 1376)  has not been defined in the method. The array was necessary to detect the true entities (`ac_type`) for virtual entities (lines `1381` and `1389`),
